### PR TITLE
fixed isReady method

### DIFF
--- a/Stockfish.NET/Core/Stockfish.cs
+++ b/Stockfish.NET/Core/Stockfish.cs
@@ -115,26 +115,19 @@ namespace Stockfish.NET.Core
         /// </summary>
         /// <returns></returns>
         /// <exception cref="MaxTriesException"></exception>
-        private bool isReady()
+		private bool isReady()
         {
-            send("isready");
-            var tries = 0;
-            while (true)
-            {
-                if (tries > MAX_TRIES)
-                {
-                    throw new MaxTriesException();
-                }
+			send("isready");
+			var tries = 0;
+			while (tries < MAX_TRIES) {
+				++tries;
 
-                var data = _stockfish.ReadLine();
-                if (data == "readyok")
-                {
-                    return true;
-                }
-
-                return false;
-            }
-        }
+				if (_stockfish.ReadLine() == "readyok") {
+					return true;
+				}
+			}
+			throw new MaxTriesException();
+		}
 
         /// <summary>
         /// 


### PR DESCRIPTION
The isReady method did not make use of MAX_TRIES and never incremented tries. There was no path that would allow the while loop to complete even one full iteration. Now, isReady will correctly try for the "readok" signal up to MAX_TRIES times. The function never returns false. It either returns true or throws a MaxTriesException.

A further change in the code would be beneficial: remove all of the if(!isReady()) conditionals and simply invoke isReady();. An exception will be thrown if not ready. Otherwise, code execution simply moves on to the next line.