### PR TITLE
upgrade to allow to target netstandard and/or net5.0 + linux test support

### DIFF
--- a/Stockfish.NET.Tests/Stockfish.NET.Tests.csproj
+++ b/Stockfish.NET.Tests/Stockfish.NET.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net5.0;net471</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -9,12 +9,19 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+	  <!--    <PackageReference Include="xunit.abstractions" Version="2.0.3"/> !-->
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"/>
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <!-- fix for: https://github.com/tpierrain/NFluent/issues/274 !-->
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.5.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Stockfish.NET\Stockfish.NET.csproj" />
   </ItemGroup>
+
+  <PropertyGroup>
+	  <DebugType>Full</DebugType>
+  </PropertyGroup>
 
 </Project>

--- a/Stockfish.NET.Tests/Utils.cs
+++ b/Stockfish.NET.Tests/Utils.cs
@@ -16,7 +16,15 @@ namespace Stockfish.NET.Tests
                 .GetParent(Directory.GetParent(Directory.GetParent(location).ToString())
                     .ToString()).ToString()).ToString());
             Console.WriteLine(dir);
-            var path = $@"{dir}\Stockfish.NET.Tests\Stockfish\win\stockfish_12_win_x64\stockfish_20090216_x64.exe";
+            string path = null;
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform( System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                 path = $@"{dir}\Stockfish.NET.Tests\Stockfish\win\stockfish_12_win_x64\stockfish_20090216_x64.exe";
+            }
+            else
+            {
+                path = "/usr/games/stockfish";
+            }
             return path;
         }
     }

--- a/Stockfish.NET/Core/Stockfish.cs
+++ b/Stockfish.NET/Core/Stockfish.cs
@@ -191,7 +191,7 @@ namespace Stockfish.NET.Core
         private List<string> readLineAsList()
         {
             var data = _stockfish.ReadLine();
-            return data.Split(" ").ToList();
+            return data.Split(' ').ToList();
         }
 
         #endregion
@@ -397,7 +397,7 @@ namespace Stockfish.NET.Core
             {
                 if (tries > MAX_TRIES)
                 {
-                    throw new MaxTriesException();
+                    throw new MaxTriesException("tries:"+tries+">max-tries:"+MAX_TRIES);
                 }
 
                 var data = readLineAsList();

--- a/Stockfish.NET/Exceptions/MaxTriesException.cs
+++ b/Stockfish.NET/Exceptions/MaxTriesException.cs
@@ -4,6 +4,6 @@ namespace Stockfish.NET.Exceptions
 {
     public class MaxTriesException: Exception
     {
-        
+        public  MaxTriesException(string msg="") : base(msg) { }
     }
 }

--- a/Stockfish.NET/Stockfish.NET.csproj
+++ b/Stockfish.NET/Stockfish.NET.csproj
@@ -1,10 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <AssemblyName>Stockfish.NET</AssemblyName>
     <RootNamespace>Stockfish.NET</RootNamespace>
     <NuspecFile>Stockfish.NET.nuspec</NuspecFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+	  <DebugType>Full</DebugType>
   </PropertyGroup>
 
 </Project>

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -1,0 +1,5 @@
+{
+"MSBuild": {
+"UseLegacySdkResolver": true
+}
+}


### PR DESCRIPTION

to allow more runtime interop, targetted multiple frameworks.

this required:

* one code fix to support netstandard2.0 and net5.0 simulatenously
* a package version bump or two
* fixing stockfish tests' hardcoded windows path, so it used correct default path for ubuntu/deb
